### PR TITLE
[story/TP-94583]: Update gem dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :datamapper do
   gem 'dm-core', DM_VERSION, options.dup
 
   do_options = {}
+  # DO_GIT is for the DataObjects repo which is not managed with thor in the same way as the rest of the gems. It is possible to have SOURCE configured
+  # as path while datamapper-do should use git. Configure these options separately.
   if ENV['DO_GIT'] == 'true'
     do_options = options.dup
     do_options[SOURCE] = "#{DATAMAPPER}/datamapper-do#{REPO_POSTFIX}"

--- a/dm-mysql-adapter.gemspec
+++ b/dm-mysql-adapter.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7.8'
 
   gem.add_runtime_dependency('dm-do-adapter', ['~> 1.3.0.beta'])
-  gem.add_runtime_dependency('do_mysql',      ['~> 0.10.6'])
+  gem.add_runtime_dependency('do_mysql', ['~> 0.10.17'])
 end


### PR DESCRIPTION
# Topic

TargetProcess Link: https://sbf.tpondemand.com/entity/94583

## How to test
* [How to PR](https://github.com/firespring/sbf/blob/master/documentation/guides/processes/pull_requests.md#reviewing-pull-requests)

### Functionality
* Update to use correct version of data_objects gems
* Ignore ide files

### PRs for this story from other repos
* [dm-dev](https://github.com/firespring/dm-dev/pull/4)
* data_mapper - No changes 
* [datamapper-do](https://github.com/firespring/datamapper-do/pull/5)
* [dm-aggregates] - No changes
* [dm-constraints] - No changes
* [dm-core] - No changes
* [dm-do-adapter](https://github.com/firespring/dm-do-adapter/pull/4)
* **dm-mysql-adapter - This PR**
* [dm-noisy-failures] - No changes
* [dm-serializer] - No changes
* [dm-sqlite-adapter](https://github.com/firespring/dm-sqlite-adapter/pull/1)
* [dm-timestamps] - No changes
* [dm-transactions] - No changes
* [dm-types] - No changes
* [dm-validations] - No changes